### PR TITLE
Updated asttokens, mypy and pylint to latest

### DIFF
--- a/pylint.rc
+++ b/pylint.rc
@@ -7,5 +7,5 @@ generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace
+disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,no-else-raise
 

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
     license='License :: OSI Approved :: MIT License',
     keywords='contracts sphinx extension icontract design-by-contract',
     packages=find_packages(exclude=['tests']),
-    install_requires=['icontract>=2.0.0,<3', 'sphinx', 'asttokens>=1.1.11,<2'],
+    install_requires=['icontract>=2,<3', 'sphinx', 'asttokens>=2,<3'],
     extras_require={
         'dev': [
-            'mypy==0.620', 'pylint==2.1.1', 'yapf==0.20.2', 'tox>=3.0.0', 'pyicontract-lint>=2.0.0,<3',
+            'mypy==0.790', 'pylint==2.6.0', 'yapf==0.20.2', 'tox>=3.0.0', 'pyicontract-lint>=2.0.0,<3',
             'pydocstyle>=2.1.1,<3', 'coverage>=4.5.1,<5'
         ]
     },

--- a/sphinx_icontract/__init__.py
+++ b/sphinx_icontract/__init__.py
@@ -192,6 +192,8 @@ def _format_contract(contract: icontract._Contract) -> str:
         # Find the line corresponding to the condition lambda
         lines, condition_lineno = inspect.findsource(contract.condition)
         filename = inspect.getsourcefile(contract.condition)
+        if filename is None:
+            filename = "<filename unavailable>"
 
         decorator_inspection = icontract._represent.inspect_decorator(
             lines=lines, lineno=condition_lineno, filename=filename)
@@ -219,6 +221,8 @@ def _format_contract(contract: icontract._Contract) -> str:
             if decorator_inspection is None:
                 lines, condition_lineno = inspect.findsource(contract.error)
                 filename = inspect.getsourcefile(contract.error)
+                if filename is None:
+                    filename = "<filename unavailable>"
 
                 decorator_inspection = icontract._represent.inspect_decorator(
                     lines=lines, lineno=condition_lineno, filename=filename)
@@ -310,6 +314,9 @@ def _capture_as_text(capture: Callable[..., Any]) -> str:
 
     lines, lineno = inspect.findsource(capture)
     filename = inspect.getsourcefile(capture)
+    if filename is None:
+        filename = "<filename unavailable>"
+
     decorator_inspection = icontract._represent.inspect_decorator(lines=lines, lineno=lineno, filename=filename)
 
     call_node = decorator_inspection.node
@@ -471,7 +478,7 @@ def _format_function_contracts(func: Callable, prefix: Optional[str] = None) -> 
 def _format_property_contracts(prop: property) -> List[str]:
     result = []  # type: List[str]
     for func, prefix in zip([prop.fget, prop.fset, prop.fdel], ['get', 'set', 'del']):
-        result.extend(_format_function_contracts(func=func, prefix=prefix))
+        result.extend(_format_function_contracts(func=func, prefix=prefix))  # type: ignore
 
     return result
 


### PR DESCRIPTION
This change updates the latest versions of the dependencies asttokens,
mypy and pylint, respectively.

* asttokens: tuple nodes can be correctly parsed
* mypy and pylint: keep up with the time