### PR TITLE
Added support for development in Windows

### DIFF
--- a/precommit.py
+++ b/precommit.py
@@ -31,26 +31,26 @@ def main() -> int:
                 "yapf", "--in-place", "--style=style.yapf", "--recursive", "tests", "sphinx_icontract", "setup.py",
                 "precommit.py"
             ],
-            cwd=repo_root.as_posix())
+            cwd=str(repo_root))
     else:
         subprocess.check_call(
             [
                 "yapf", "--diff", "--style=style.yapf", "--recursive", "tests", "sphinx_icontract", "setup.py",
                 "precommit.py"
             ],
-            cwd=repo_root.as_posix())
+            cwd=str(repo_root))
 
     print("Mypy'ing...")
-    subprocess.check_call(["mypy", "sphinx_icontract", "tests"], cwd=repo_root.as_posix())
+    subprocess.check_call(["mypy", "sphinx_icontract", "tests"], cwd=str(repo_root))
 
     print("Pyicontract-lint'ing...")
-    subprocess.check_call(["pyicontract-lint", "tests", "sphinx_icontract"], cwd=repo_root.as_posix())
+    subprocess.check_call(["pyicontract-lint", "tests", "sphinx_icontract"], cwd=str(repo_root))
 
     print("Pylint'ing...")
-    subprocess.check_call(["pylint", "--rcfile=pylint.rc", "tests", "sphinx_icontract"], cwd=repo_root.as_posix())
+    subprocess.check_call(["pylint", "--rcfile=pylint.rc", "tests", "sphinx_icontract"], cwd=str(repo_root))
 
     print("Pydocstyle'ing...")
-    subprocess.check_call(["pydocstyle", "sphinx_icontract"], cwd=repo_root.as_posix())
+    subprocess.check_call(["pydocstyle", "sphinx_icontract"], cwd=str(repo_root))
 
     print("Testing...")
     env = os.environ.copy()
@@ -58,15 +58,15 @@ def main() -> int:
 
     subprocess.check_call(
         ["coverage", "run", "--source", "sphinx_icontract", "-m", "unittest", "discover", "tests"],
-        cwd=repo_root.as_posix(),
+        cwd=str(repo_root),
         env=env)
 
     subprocess.check_call(["coverage", "report"])
 
     print("Doctesting...")
-    subprocess.check_call(["python3", "-m", "doctest", (repo_root / "README.rst").as_posix()])
+    subprocess.check_call([sys.executable, "-m", "doctest", str(repo_root / "README.rst")])
     for pth in (repo_root / "sphinx_icontract").glob("**/*.py"):
-        subprocess.check_call(["python3", "-m", "doctest", pth.as_posix()])
+        subprocess.check_call([sys.executable, "-m", "doctest", str(pth)])
 
     return 0
 


### PR DESCRIPTION
This change makes it possible to develop the library in Windows, mainly
by fixing the executable (referenced now through `sys.executable`) and
handling paths in platform-independent way (`str(.)` instead of
`.as_posix()`).