### PR TITLE
Fixed support for multi-line lambda inspections

### DIFF
--- a/pylint.rc
+++ b/pylint.rc
@@ -7,5 +7,5 @@ generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,no-else-raise
+disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,no-else-raise,unnecessary-pass,too-many-statements
 


### PR DESCRIPTION
Previously, multi-line condition lambdas or capture lambdas caused
post-condition violations as we expected a single-lined code snippets
(rightly so).

This patch translates multi-line lambda texts into `.. code-block` lines
so that the lambda texts are correctly rendered as blocks of lines.