### PR TITLE
Dropped support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ Namely, we use:
 * Static type analysis is performed with `mypy <http://mypy-lang.org/>`_.
 * Various linter checks are done with `pylint <https://www.pylint.org/>`_.
 * Contracts are linted with `pyicontract-lint <https://github.com/Parquery/pyicontract-lint>`_.
-* Doctests are executed using the Python `doctest module <https://docs.python.org/3.5/library/doctest.html>`_.
+* Doctests are executed using the Python `doctest module <https://docs.python.org/3.8/library/doctest.html>`_.
 
 Run the pre-commit checks locally from an activated virtual environment with development dependencies:
 

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,8 @@ setup(
     author_email=sphinx_icontract_meta.__author_email__,
     classifiers=[
         'Development Status :: 5 - Production/Stable', 'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License', 'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6', 'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'License :: OSI Approved :: MIT License', 'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7', 'Programming Language :: Python :: 3.8'
     ],
     license='License :: OSI Approved :: MIT License',
     keywords='contracts sphinx extension icontract design-by-contract',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py36,py37,py38
 
 [testenv]
 deps = .[dev]


### PR DESCRIPTION
Python 3.5 reached end-of-life in September 2020.