### PR TITLE
Released 2.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+2.0.3
+=====
+* Added newline before contract description (#31)
+* Fixed support for multi-line lambda inspections (#27)
+* Dropped support for Python 3.5 (#30)
+* Fixed mypy issue with ``callable`` (#29)
+
 2.0.2
 =====
 *  Fixed compatibility with `icontract` >=2.4.0 (#24)

--- a/sphinx_icontract_meta.py
+++ b/sphinx_icontract_meta.py
@@ -3,7 +3,7 @@
 __title__ = 'sphinx-icontract'
 __description__ = 'Extend sphinx to include icontracts.'
 __url__ = 'https://github.com/Parquery/sphinx-icontract'
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 __author__ = 'Marko Ristin'
 __author_email__ = 'marko.ristin@gmail.com'
 __license__ = 'MIT'


### PR DESCRIPTION
* Added newline before contract description (#31)
* Fixed support for multi-line lambda inspections (#27)
* Dropped support for Python 3.5 (#30)
* Fixed mypy issue with `callable` (#29)